### PR TITLE
Add a question about the opt-out mechanism

### DIFF
--- a/request.md
+++ b/request.md
@@ -53,6 +53,8 @@
 
 * Any other filters?  Please describe in detail below.
 
-8) Please provide a general description of how you will analyze this data.
+8) If this data collection is default on, what is the opt-out mechanism for users?
 
-9) Where do you intend to share the results of your analysis?
+9) Please provide a general description of how you will analyze this data.
+
+10) Where do you intend to share the results of your analysis?


### PR DESCRIPTION
I thought about adding a question to the request form because sometimes (e.g. the non-telemetry cases) the opt-out mechanism is not obvious.

But then I thought about it again and the opt out needs to be clearly spelled out in our documentation. If it's not obvious from the request, the documentation should get an r- and get fixed.

In fact, if it's not in the request form then the data steward will need to double-check that it's part of the public documentation before answering the question in the review form.

What do you think @rjweiss @liuche ?